### PR TITLE
Make Black Hive insectoids hostile to the colony in 1.4

### DIFF
--- a/1.4/Defs/FactionDefs/Factions_Hidden.xml
+++ b/1.4/Defs/FactionDefs/Factions_Hidden.xml
@@ -36,6 +36,7 @@
 			<min>-30</min>
 			<max>60</max>
 		</allowedArrivalTemperatureRange>
+		<maxConfigurableAtWorldCreation>1</maxConfigurableAtWorldCreation>
 		<modExtensions>
 			<li Class="VFECore.ExcludeFromQuestsExtension" />
 		</modExtensions>


### PR DESCRIPTION
In 1.4, factions lacking a `maxConfigurableAtWorldCreation` value do not get automatically added to the game anymore. Since the `AA_BlackHive` faction was not in the game, the insectoids created by `Building_BlackHiveMound` had their faction set to null, resulting in them not being hostile to anyone.

For some unfathomable reason, factions without a `maxConfigurableAtWorldCreation` still get added to the game like in 1.3 when using the “Dev Quicktest” feature.

Setting `maxConfigurableAtWorldCreation` to 1 for `AA_BlackHive` ensures that the faction is present in every new game. 