### PR TITLE
Added support for Giddy-Up 2

### DIFF
--- a/1.4/Patches/GiddyUp2Patch.xml
+++ b/1.4/Patches/GiddyUp2Patch.xml
@@ -1,0 +1,1842 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Giddy-Up 2</li>
+			<li>Giddy-Up 2 (temporary beta)</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAddModExtension">
+					<!-- Only animals with size of 1.2 or less need the Mountable extension, as all above this size are mountable by default. -->
+					<xpath>/Defs/ThingDef[defName = "AA_MeadowAve" or "AA_DesertAve" or "AA_NightAve" or "AA_RoyalAve" or "AA_Feralisk" or "AA_Junglelisk" or "AA_DecayDrake" or "AA_Nightling" or "AA_Razorjack" or "AA_BlackSpelopede"]</xpath>
+					<value>
+						<li Class="GiddyUp.Mountable"/>
+					</value>
+				</li>
+
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_MeadowAve"]</xpath>
+					<value>
+						<li Class="GiddyUp.CustomStats">
+							<!--Speed factor. -->
+							<speedModifier>1.5</speedModifier>
+							<!--Armor factor. -->
+							<armorModifier>1</armorModifier>
+							<!--Setting useMetalArmor to true, makes the animal's skin have the metal bounce of effect when hit when used as mount -->
+							<useMetalArmor>false</useMetalArmor>
+						</li>
+                        <li Class="GiddyUp.DrawingOffset">
+                            <southOffset>0,0,0.3</southOffset>
+                        </li>
+						<li Class="GiddyUp.DrawInFront"/>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_DesertAve"]</xpath>
+					<value>
+						<li Class="GiddyUp.CustomStats">
+							<!--Speed factor. -->
+							<speedModifier>1.5</speedModifier>
+							<!--Armor factor. -->
+							<armorModifier>1</armorModifier>
+							<!--Setting useMetalArmor to true, makes the animal's skin have the metal bounce of effect when hit when used as mount -->
+							<useMetalArmor>false</useMetalArmor>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_FrostAve"]</xpath>
+					<value>
+						<li Class="GiddyUp.CustomStats">
+							<!--Speed factor. -->
+							<speedModifier>1.5</speedModifier>
+							<!--Armor factor. -->
+							<armorModifier>1</armorModifier>
+							<!--Setting useMetalArmor to true, makes the animal's skin have the metal bounce of effect when hit when used as mount -->
+							<useMetalArmor>false</useMetalArmor>
+						</li>
+                        <li Class="GiddyUp.DrawingOffset">
+                            <southOffset>0,0,0.3</southOffset>
+                        </li>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_NightAve"]</xpath>
+					<value>
+						<li Class="GiddyUp.CustomStats">
+							<!--Speed factor. -->
+							<speedModifier>1.5</speedModifier>
+							<!--Armor factor. -->
+							<armorModifier>1</armorModifier>
+							<!--Setting useMetalArmor to true, makes the animal's skin have the metal bounce of effect when hit when used as mount -->
+							<useMetalArmor>false</useMetalArmor>
+						</li>
+                        <li Class="GiddyUp.DrawingOffset">
+                            <southOffset>0,0,0.3</southOffset>
+                        </li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_RoyalAve"]</xpath>
+					<value>
+						<li Class="GiddyUp.CustomStats">
+							<!--Speed factor. -->
+							<speedModifier>1.5</speedModifier>
+							<!--Armor factor. -->
+							<armorModifier>1</armorModifier>
+							<!--Setting useMetalArmor to true, makes the animal's skin have the metal bounce of effect when hit when used as mount -->
+							<useMetalArmor>false</useMetalArmor>
+						</li>
+						<li Class="GiddyUp.DrawingOffset">
+							<eastOffset>0.50,0,-0.3</eastOffset>
+							<westOffset>-0.50,0,-0.3</westOffset>
+							<northOffset>0,0,-0.268</northOffset>
+							<southOffset>0,0,-0.234</southOffset>
+						</li>
+						<li Class="GiddyUp.DrawInFront"/>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_MammothWorm"]</xpath>
+					<value>
+						<li Class="GiddyUp.CustomStats">
+							<!--Speed factor.  -->
+							<speedModifier>1.25</speedModifier>
+							<!--Armor factor.  -->
+							<armorModifier>1.5</armorModifier>
+							<!--Setting useMetalArmor to true, makes the animal's skin have the metal bounce of effect when hit when used as mount -->
+							<useMetalArmor>true</useMetalArmor>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_ColossalAerofleet"]/comps</xpath>
+					<value>
+
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle1_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>					
+								<offsetDefault>(0,0,0.7,0)</offsetDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle1_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>					
+								<offsetDefault>(0,0,0.8,0)</offsetDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle1_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>					
+								<offsetDefault>(0,0,0.8,0)</offsetDefault>
+							</overlayBack>
+
+						</li>
+
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_ArcticLion"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle2_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle2ArcticLion_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle2_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Barbslinger"]</xpath>
+					<value>
+						<comps>
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle3_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlaySide>
+								<overlayFront>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle3_south</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayFront>
+								<overlayBack>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle3_north</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayBack>
+
+							</li>
+						</comps>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Blizzarisk"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_BlizzariskClutchMother"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_DunealiskClutchMother"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Dunealisk"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_FeraliskClutchMother"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Feralisk"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Junglelisk"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.85</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.85</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.85</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_Cinderlisk"]</xpath>
+					<value>
+						<li Class="GiddyUp.DrawingOffset">
+							<eastOffset>0.0,0,-0.25</eastOffset>
+							<westOffset>-0.0,0,-0.25</westOffset>
+							<northOffset>0,0,-0.25</northOffset>
+							<southOffset>0,0,-0.25</southOffset>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Cinderlisk"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle4_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_BoulderMit"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle5_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle5_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle5_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_SummitCrab"]/comps</xpath>
+					<value>
+						
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle5_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlaySide>
+								<overlayFront>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle5_south</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayFront>
+								<overlayBack>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle5_north</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayBack>
+
+							</li>
+						
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_ChameleonYak"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/GR_Saddle_Muffalos_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/GR_Saddle_Muffalos_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/GR_Saddle_Muffalos_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_DecayDrake"]</xpath>
+					<value>
+						<li Class="GiddyUp.DrawingOffset">
+							<eastOffset>0.337,0,0.26</eastOffset>
+							<westOffset>-0.337,0,0.26</westOffset>
+							<northOffset>0,0,0.22</northOffset>
+							<southOffset>0,0,0.11</southOffset>
+						</li>
+						<li Class="GiddyUp.DrawInFront"/>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_DecayDrake"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_DecayDrakeSaddle_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.75</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_DesertAve"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_DesertAveSaddle_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.75</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_FrostAve"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostAveSaddle_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.15</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_FrostboundBehemoth"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostboundBehemothSaddle_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.1</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostboundBehemothSaddle_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.1</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostboundBehemothSaddle_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.1</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Frostling"]</xpath>
+					<value>
+						<comps>
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_FrostlingSaddle_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlaySide>
+								<overlayFront>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_FrostlingSaddle_south</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayFront>
+								<overlayBack>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_FrostlingSaddle_north</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayBack>
+
+							</li>
+						</comps>
+					</value>
+				</li>
+
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Gallatross"]/comps</xpath>
+					<value>
+						
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle5Gallatross_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>4.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlaySide>
+								<overlayFront>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle5Gallatross_south</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>4.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayFront>
+								<overlayBack>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle5Gallatross_north</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>4.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayBack>
+
+							</li>
+						
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_Gigantelope"]</xpath>
+					<value>
+						<li Class="GiddyUp.DrawingOffset">
+							<eastOffset>0.1,0,-0.8</eastOffset>
+							<westOffset>0.1,0,-0.8</westOffset>
+							<northOffset>0,0,-0.643</northOffset>
+							<southOffset>0,0,-0.643</southOffset>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Gigantelope"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_GigantelopeSaddle_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_GigantelopeSaddle_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_GreatDevourer"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle6_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle6GreatDevourer_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle6_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Groundrunner"]</xpath>
+					<value>
+						<comps>
+
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle7_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlaySide>
+								<overlayFront>
+									<graphicDataDefault>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+									</graphicDataDefault>
+									<allVariants>
+										<li>
+											<texPath>Things/Pawn/Animal/Saddles/AA_GroundRunner-_south</texPath>
+										</li>
+										<li>
+											<texPath>Things/Pawn/Animal/Saddles/AA_GroundRunner2-_south</texPath>
+										</li>			
+										<li>
+											<texPath>Things/Pawn/Animal/Saddles/AA_GroundRunner3-_south</texPath>
+										</li>			
+										<li>
+											<texPath>Things/Pawn/Animal/Saddles/AA_GroundRunner4-_south</texPath>
+										</li>			
+										<li>
+											<texPath>Things/Pawn/Animal/Saddles/AA_GroundRunner5-_south</texPath>
+										</li>			
+										<li>
+											<texPath>Things/Pawn/Animal/Saddles/AA_GroundRunnerW-_south</texPath>
+										</li>		
+
+									</allVariants>
+									<stringDelimiter>-</stringDelimiter>
+								</overlayFront>
+								<overlayBack>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle7_north</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayBack>
+
+							</li>
+						</comps>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_IronhuskBeetle"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle8_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle8_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle8_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Lockjaw"]</xpath>
+					<value>
+						<comps>
+
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle9_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>3.75</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlaySide>
+								<overlayFront>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle9_south</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>3.75</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayFront>
+								<overlayBack>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle9_north</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>3.75</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayBack>
+
+							</li>
+						</comps>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_MammothWorm"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle10_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.1</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle10_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.1</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle10_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.1</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_MeadowAve"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+
+							<overlayFront>
+								<graphicDataDefault>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+								</graphicDataDefault>
+								<allVariants>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_1-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_2-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_3-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_4-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_5-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_6-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_7-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_8-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_9-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_10-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_11-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_12-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_13-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_14-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_15-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_16-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_17-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_18-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_19-Saddle_south</texPath>
+									</li>
+									<li>
+										<texPath>Things/Pawn/Animal/Saddles/AA_MeadowAve_20-Saddle_south</texPath>
+									</li>
+
+
+								</allVariants>
+								<stringDelimiter>-</stringDelimiter>
+							</overlayFront>
+
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_NightAve"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_NightAveSaddle_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName = "AA_Nightling"]</xpath>
+					<value>
+						<li Class="GiddyUp.DrawingOffset">
+							<eastOffset>0.205,0,-0.48</eastOffset>
+							<westOffset>-0.205,0,-0.48</westOffset>
+							<northOffset>0,0,-0.48</northOffset>
+							<southOffset>0,0,-0.48</southOffset>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Nightling"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle11_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.05</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle11_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.05</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle11_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.05</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_NightMule"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_NightMuleSaddle_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle3_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle3_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_NightRam"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_NightRamSaddle_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_NightRamSaddle_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_NightRamSaddle_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_OvergrownColossus"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle12_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>6</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle12_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>6</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle12_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>6</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_MycoidColossus"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle12_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>6</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle12_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>6</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle12_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>6</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Radyak"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle3_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_RadYakSaddle_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle3_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_RaptorShrimp"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle13_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle13_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle13_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Razorjack"]/comps</xpath>
+					<value>
+
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostlingSaddle_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostlingSaddle_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostlingSaddle_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_RipperHound"]</xpath>
+					<value>
+						<comps>
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_RipperHoundSaddle_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlaySide>
+							</li>
+						</comps>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_RoyalAve"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+
+							<overlayFront>
+								<graphicDataDefault>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3</drawSize>
+									<drawRotated>false</drawRotated>
+								</graphicDataDefault>
+								<allVariants>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAveGreen-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAveOrange-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAveRainbow-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAveRed-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAveYellow-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve1-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve2-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve3-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve4-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve5-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve6-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve7-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve8-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve9-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve10-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve11-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve12-saddle_south</texPath></li>
+									<li><texPath>Things/Pawn/Animal/Saddles/AA_RoyalAve13-saddle_south</texPath></li>
+
+								</allVariants>
+								<stringDelimiter>-</stringDelimiter>
+							</overlayFront>
+
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_SandLion"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostlingSaddle_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostlingSaddle_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_FrostlingSaddle_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>2.5</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Slurrypede"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle14_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle14_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle14_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.3</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_TetraSlug"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle14_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.1</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>					
+								<offsetDefault>(0,0,-0.224,0)</offsetDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle14_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.1</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>					
+								<offsetDefault>(0,0,-0.224,0)</offsetDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle14_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>4.1</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>					
+								<offsetDefault>(0,0,-0.224,0)</offsetDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_BlackSpider"]/comps</xpath>
+					<value>
+						
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle15_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlaySide>
+								<overlayFront>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle15_south</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayFront>
+								<overlayBack>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle15_north</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>2.5</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>
+								</overlayBack>
+
+							</li>
+						
+
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_BlackSpelopede"]/comps</xpath>
+					<value>
+						
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle15_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>1.65</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>					
+									<offsetDefault>(0.025,0,-0.115,0)</offsetDefault>
+								</overlaySide>
+								<overlayFront>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle15_south</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>1.65</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>					
+									<offsetDefault>(0,0,-0.115,0)</offsetDefault>
+								</overlayFront>
+								<overlayBack>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle15_north</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>1.65</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>					
+									<offsetDefault>(0,0,-0.115,0)</offsetDefault>
+								</overlayBack>
+
+							</li>
+						
+
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Thermadon"]/comps</xpath>
+					<value>
+						
+							<li Class="GiddyUp.CompProperties_Overlay">
+								<overlaySide>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle15_east</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>3</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>					
+									<offsetDefault>(0.22,0,-0.3,0)</offsetDefault>
+								</overlaySide>
+								<overlayFront>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle15_south</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>3</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>					
+									<offsetDefault>(0,0,-0.3,0)</offsetDefault>
+								</overlayFront>
+								<overlayBack>
+									<graphicDataDefault>
+										<texPath>Things/Pawn/Animal/Saddles/AA_Saddle15_north</texPath>
+										<graphicClass>Graphic_Single</graphicClass>
+										<drawSize>3</drawSize>
+										<drawRotated>false</drawRotated>
+
+									</graphicDataDefault>					
+									<offsetDefault>(0,0,-0.3,0)</offsetDefault>
+								</overlayBack>
+
+							</li>
+						
+
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Wildpod"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle16_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.8</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle16_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.8</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle16_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.8</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "AA_Agaripod"]/comps</xpath>
+					<value>
+						<li Class="GiddyUp.CompProperties_Overlay">
+							<overlaySide>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle16_east</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.8</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlaySide>
+							<overlayFront>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle16_south</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.8</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayFront>
+							<overlayBack>
+								<graphicDataDefault>
+									<texPath>Things/Pawn/Animal/Saddles/AA_Saddle16_north</texPath>
+									<graphicClass>Graphic_Single</graphicClass>
+									<drawSize>3.8</drawSize>
+									<drawRotated>false</drawRotated>
+
+								</graphicDataDefault>
+							</overlayBack>
+
+						</li>
+					</value>
+				</li>
+
+
+			</operations>
+		</match>
+	</Operation>
+
+
+</Patch>
+


### PR DESCRIPTION
I've originally planned to see how well GU2 performs, but realized that all mod patches needed updating... So I just patched everything, reported some issues with the GU2 beta, and did some adjustments to the original patch.

I've left the patch for original Giddy-Up as is for people who may still use it - removing it is going to be safe (and will most likely be a smart move once a new major RW version drops).

I could move those mod extensions/comps to the animal .xml files and used `MayRequire="Owlchemist.GiddyUp"`. I've left it as an .xml patch to not mess too much with the mod without getting a go-ahead beforehand.

As for the changes compared to the original Giddy-Up (besides the required ones to make it work with the new one):

* I'm unsure of what the default allowed size was in original Giddy-Up, but in GU2 only animals bigger than 1.2 are mountable by default (so 1.2 and below aren't). The `GiddyUp.Mountable` mod extension was added to add default ones - which I've added to all animals that currently have any sort of overlay, mod extension, etc., with body size of 1.2 or smaller.

* I've adjusted the drawing offsets for some of royal aves, decay drakes, gigantalopes - previously the pawns riding them were somewhat looking like they were floating in the air.

* I've removed all the `offsetDefault` where the value was `0,0,0` - this is the default value anyway, so it was just increasing the size of the file.

* I've added offset for south-facing meadow, frost, and night aves. Previously, the pawns had their heads covered by them - I've changed it so the pawn heads are more visible now when they're riding them, so it'll look like they can actually see.

As an additional side not - south-facing decay drake doesn't look too good while mounted... Could use an overlay with wings, so they cover the riding pawn. I'm not all that good with graphics and the like, so I left it as-is.