### PR TITLE
Update fangsquid to use the new Biomes! Islands pathfinding code

### DIFF
--- a/1.4/Mods/BiomesIslands/Defs/LifeStageDefs/LifeStageDefs_BiomesIslands.xml
+++ b/1.4/Mods/BiomesIslands/Defs/LifeStageDefs/LifeStageDefs_BiomesIslands.xml
@@ -6,17 +6,7 @@
 		<foodMaxFactor>4</foodMaxFactor>
 		<statFactors>
 			<MoveSpeed>0.5</MoveSpeed>
-			<SwimSpeed>0.5</SwimSpeed>
 		</statFactors>
-		<modExtensions>
-			<li Class="TerrainMovement.TerrainMovementPawnKindGraphics">
-				<pawnSpeedStat>SwimSpeed</pawnSpeedStat>
-				<bodyGraphicData>
-					<texPath>Things/Pawn/Animal/AA_Fangsquid/AA_Fangsquid_Submerged</texPath>
-					<drawSize>1.5</drawSize>
-				</bodyGraphicData>
-			</li>
-		</modExtensions>
 	</LifeStageDef>
 	<LifeStageDef>
 		<defName>AA_BiomesIslands_Fangsquid_Juvenile</defName>
@@ -30,17 +20,7 @@
 		<meleeDamageFactor>0.75</meleeDamageFactor>
 		<statFactors>
 			<MoveSpeed>0.9</MoveSpeed>
-			<SwimSpeed>0.9</SwimSpeed>
 		</statFactors>
-		<modExtensions>
-			<li Class="TerrainMovement.TerrainMovementPawnKindGraphics">
-				<pawnSpeedStat>SwimSpeed</pawnSpeedStat>
-				<bodyGraphicData>
-					<texPath>Things/Pawn/Animal/AA_Fangsquid/AA_Fangsquid_Submerged</texPath>
-					<drawSize>2</drawSize>
-				</bodyGraphicData>
-			</li>
-		</modExtensions>
 	</LifeStageDef>
 	<LifeStageDef>
 		<defName>AA_BiomesIslands_Fangsquid_Adult</defName>
@@ -49,14 +29,5 @@
 		<reproductive>true</reproductive>
 		<milkable>true</milkable>
 		<shearable>true</shearable>
-		<modExtensions>
-			<li Class="TerrainMovement.TerrainMovementPawnKindGraphics">
-				<pawnSpeedStat>SwimSpeed</pawnSpeedStat>
-				<bodyGraphicData>
-					<texPath>Things/Pawn/Animal/AA_Fangsquid/AA_Fangsquid_Submerged</texPath>
-					<drawSize>2.5</drawSize>
-				</bodyGraphicData>
-			</li>
-		</modExtensions>
 	</LifeStageDef>
 </Defs>

--- a/1.4/Mods/BiomesIslands/Defs/ThingDefs_Races/Races_Fangsquid.xml
+++ b/1.4/Mods/BiomesIslands/Defs/ThingDefs_Races/Races_Fangsquid.xml
@@ -6,8 +6,7 @@
 		<label>fangsquid</label>
 		<description>A grotesque and terrifying creature born from the darkest depths of mutation. Resembling a mutated squid, its entire form is a nightmarish amalgamation of eyes, teeth, and tentacles. Its body is covered in a thick, slimy layer of oozing flesh, constantly secreting a sinister mixture of blood and viscera.\n\nThe Fangsquid possesses an uncanny ability to instill dread in anyone unfortunate enough to encounter it. The sheer sight of its grotesque visage and the eerie, unblinking gazes of its numerous eyes send shivers down the spines of nearby bystanders, invoking a primal sense of fear and terror.\n\n&lt;color=#E5E54C&gt;Gameplay effect:&lt;/color&gt; Psychopaths and people with the Hemogenic gene will not be affected by the psychological dread caused by the squid. If you have Biotech, the squid can be farmed for Hemogen packs.</description>
 		<statBases>
-			<MoveSpeed>0</MoveSpeed>
-			<SwimSpeed>8</SwimSpeed>
+			<MoveSpeed>4</MoveSpeed>
 			<ComfyTemperatureMin>-15</ComfyTemperatureMin>
 			<ComfyTemperatureMax>55</ComfyTemperatureMax>
 			<MarketValue>1500</MarketValue>
@@ -144,5 +143,17 @@
 				</bodyGraphicData>
 			</li>
 		</lifeStages>
+		<modExtensions>
+			<li Class="PathfindingFramework.TerrainTagGraphicExtension">
+				<terrainTags>
+					<li>PF_TerrainTag_WaterShallow</li>
+					<li>PF_TerrainTag_WaterChest</li>
+					<li>PF_TerrainTag_WaterDeep</li>
+				</terrainTags>
+				<bodyGraphicData>
+					<texPath>Things/Pawn/Animal/AA_Fangsquid/AA_Fangsquid_Submerged</texPath>
+				</bodyGraphicData>
+			</li>
+		</modExtensions>
 	</PawnKindDef>
 </Defs>


### PR DESCRIPTION
This PR updates the fangsquid to use the new pathfinding code that will be used by Biomes! Islands from the next release onwards.

* Use the new `PathfindingFramework.TerrainTagGraphicExtension` for submerged graphics. This extension automatically uses the `drawSize` values defined in `PawnKindDef.lifeStages` so it no longer needs to be defined once for each life stage.

* Remove references to `SwimSpeed` and use `MoveSpeed` instead. The new framework modifies terrain path costs and passability for each movement type instead of using custom speed stats for each movement type. All creatures use only the vanilla `MoveSpeed` stat.

For more details, see: https://github.com/joseasoler/Pathfinding-Framework/wiki/