### PR TITLE
Adding battery compability in higher power and rimatomics for electrify psycast.

### DIFF
--- a/1.5/Mods/VanillaPsycastsExpanded/Defs/HediffDefs/Hediffs_Psycasts.xml
+++ b/1.5/Mods/VanillaPsycastsExpanded/Defs/HediffDefs/Hediffs_Psycasts.xml
@@ -284,6 +284,8 @@
 					<li>AA_HexaGelBattery</li>
 					<li>ShipCapacitor</li>
 					<li>ShipCapacitorSmall</li>
+					<li>Battery_II</li>
+					<li>PPC</li>
 				</batteriesToAffect>
 			</li>
 		</comps>


### PR DESCRIPTION
Added Battery LV2 from [Higher Power ](https://steamcommunity.com/sharedfiles/filedetails/?id=1409449372&searchtext=higher+power) and PPC from [Rimatomics](https://steamcommunity.com/sharedfiles/filedetails/?id=1127530465&searchtext=rimatom) to work with electrify psycast.