### PR TITLE
Fix Hediff_Crushing errors when loading the game

### DIFF
--- a/1.5/Source/AlphaBehavioursAndEvents/AlphaBehavioursAndEvents/Hediffs/Hediff_Crushing.cs
+++ b/1.5/Source/AlphaBehavioursAndEvents/AlphaBehavioursAndEvents/Hediffs/Hediff_Crushing.cs
@@ -42,7 +42,7 @@ namespace AlphaBehavioursAndEvents
                    
                     this.CreateSustainer();
                 }
-                if (!this.sustainer.Ended)
+                else if (!this.sustainer.Ended)
                 {
                     this.sustainer.Maintain();
 


### PR DESCRIPTION
When loading a game when a pawn has `Hediff_Crushing` it will cause an error and remove the hediff.

Inside ticking if sustainer is null the method `CreateSustainer` will be called - the code assumes the sustainer is not null and operates on it. The issue happens due to the method `CreateSustainer` creating the sustainer inside a delegate passed to `LongEventHandler.ExecuteWhenFinished`. During normal ticking the delegate will be called immediately, but when loading it'll be delayed - meaning that the sustainer is still null after calling `CreateSustainer`, and the code is trying to maintain a null sustainer.

The simplest fix I could thing of is to use `if/else if` rather than `if/if`, ensuring that the second if statement is only called when the sustainer is guaranteed not null. If the sustainer was created in the `CreateSustainer` method` the `lastMaintainTick` should have been set in constructor anyway, so there should be no point in calling `Maintain`.