### PR TITLE
Update VFE - Insectoids 2 compat

### DIFF
--- a/1.6/Mods/VFEInsectoids2/Defs/TerrainDefs/Terrain_Floors_Insectoids.xml
+++ b/1.6/Mods/VFEInsectoids2/Defs/TerrainDefs/Terrain_Floors_Insectoids.xml
@@ -9,6 +9,7 @@
     <edgeType>FadeRough</edgeType>
     <renderPrecedence>70</renderPrecedence>
     <isPaintable>false</isPaintable>
+    <pathCost>46</pathCost>
     <statBases>
       <Beauty>-1</Beauty>
       <Cleanliness>-2</Cleanliness>
@@ -28,6 +29,9 @@
     <uiOrder>2020</uiOrder>
 	<designationCategory inherit ="False"/>
 	<burnedDef>VFEI2_BurnedCreep</burnedDef>
+    <tags>
+      <li>VFEI2_Creep</li>
+    </tags>
   </TerrainDef>
   
  

--- a/1.6/Mods/VFEInsectoids2/Patches/GeneDefs_Evolutions_BlackHive.xml
+++ b/1.6/Mods/VFEInsectoids2/Patches/GeneDefs_Evolutions_BlackHive.xml
@@ -22,7 +22,7 @@
 						<li>InsectorGlands</li>
 					</exclusionTags>
 					<modExtensions>
-						<li Class="VanillaGenesExpanded.GeneExtension">
+						<li Class="VEF.Genes.GeneExtension">
 							<backgroundPathEndogenes>UI/Icons/Genes/VRE_EvolutionBG</backgroundPathEndogenes>
 							<backgroundPathXenogenes>UI/Icons/Genes/VRE_EvolutionBG</backgroundPathXenogenes>
 						</li>
@@ -42,7 +42,7 @@
 						<li>Hands</li>
 					</exclusionTags>
 					<modExtensions>
-						<li Class="VanillaGenesExpanded.GeneExtension">
+						<li Class="VEF.Genes.GeneExtension">
 							<backgroundPathEndogenes>UI/Icons/Genes/VRE_EvolutionBG</backgroundPathEndogenes>
 							<backgroundPathXenogenes>UI/Icons/Genes/VRE_EvolutionBG</backgroundPathXenogenes>
 							<hediffsToBodyParts>

--- a/1.6/Mods/VFEInsectoids2/Patches/GeneDefs_Mutations_BlackHive.xml
+++ b/1.6/Mods/VFEInsectoids2/Patches/GeneDefs_Mutations_BlackHive.xml
@@ -19,7 +19,7 @@
 						<li>Any damage of type Bomb caused to the carrier will trigger a catatonic breakdown.</li>
 					</customEffectDescriptions>
 					<modExtensions>
-						<li Class="VanillaGenesExpanded.GeneExtension">
+						<li Class="VEF.Genes.GeneExtension">
 							<hediffToWholeBody>AA_EcholocativeFeedbackLoop</hediffToWholeBody>
 							<backgroundPathEndogenes>UI/Icons/Genes/VRE_MutationBG</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/VRE_MutationBG</backgroundPathXenogenes>
@@ -46,7 +46,7 @@
 						<li>Will periodically be dissoriented under direct sunlight</li>
 					</customEffectDescriptions>
 					<modExtensions>
-						<li Class="VanillaGenesExpanded.GeneExtension">
+						<li Class="VEF.Genes.GeneExtension">
 							<backgroundPathEndogenes>UI/Icons/Genes/VRE_MutationBG</backgroundPathEndogenes>
 				<backgroundPathXenogenes>UI/Icons/Genes/VRE_MutationBG</backgroundPathXenogenes>
 						</li>


### PR DESCRIPTION
Black creep TerrainDef updated to match changes to creep from Insectoids 2:
- pathCost is now 46 (was 0)
- Added terrain tag 'VFEI2_Creep'

On top of that, there were 4 instances of `VanillaGenesExpanded.GeneExtension` that I've replaced with `VEF.Genes.GeneExtension`.