### PR TITLE
Update animal XML

### DIFF
--- a/1.6/Defs/ThingDefs_Races/Bases.xml
+++ b/1.6/Defs/ThingDefs_Races/Bases.xml
@@ -5,7 +5,7 @@
 			<ToxicResistance>1</ToxicResistance>
 			<ComfyTemperatureMax>75</ComfyTemperatureMax>
 			 <VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">1</VacuumResistance>
-			<ToxicEnvironmentResistance MayRequire="Ludeon.RimWorld.Biotech">0.8</ToxicEnvironmentResistance>
+			<ToxicEnvironmentResistance>0.8</ToxicEnvironmentResistance>
 		</statBases>
 		<race>
 			<fleshType>Insectoid</fleshType>
@@ -29,7 +29,7 @@
 			<ToxicResistance>1</ToxicResistance>
 			<ComfyTemperatureMax>60</ComfyTemperatureMax>
 			 <VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">1</VacuumResistance>
-			<ToxicEnvironmentResistance MayRequire="Ludeon.RimWorld.Biotech">0.8</ToxicEnvironmentResistance>
+			<ToxicEnvironmentResistance>0.8</ToxicEnvironmentResistance>
 		</statBases>
 		<race>
 			<fleshType>Insectoid</fleshType>

--- a/1.6/Defs/ThingDefs_Races/Races_BlackHive.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_BlackHive.xml
@@ -88,12 +88,13 @@
 			</li>
 		</modExtensions>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_BlackScarab</defName>
 		<label>black scarab</label>
 		<race>AA_BlackScarab</race>
 		<combatPower>50</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
+		<defaultFactionDef IsNull="True" />
 		<alternateGraphicChance>1</alternateGraphicChance>
 		<alternateGraphics>
 			<li>
@@ -250,12 +251,13 @@
 			</li>
 		</modExtensions>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_BlackSpelopede</defName>
 		<label>black spelopede</label>
 		<race>AA_BlackSpelopede</race>
 		<combatPower>85</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
+		<defaultFactionDef IsNull="False" />
 		<alternateGraphicChance>1</alternateGraphicChance>
 		<alternateGraphics>
 			<li>
@@ -412,12 +414,13 @@
 			</li>
 		</modExtensions>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_BlackSpider</defName>
 		<label>blackspider</label>
 		<race>AA_BlackSpider</race>
 		<combatPower>175</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
+		<defaultFactionDef IsNull="False" />
 		<alternateGraphicChance>1</alternateGraphicChance>
 		<alternateGraphics>
 			<li>

--- a/1.6/Defs/ThingDefs_Races/Races_Helixien.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Helixien.xml
@@ -11,7 +11,7 @@
 			<MarketValue>750</MarketValue>
 			<LeatherAmount>0</LeatherAmount>
 			<FilthRate>8</FilthRate>
-			<ToxicEnvironmentResistance MayRequire="Ludeon.RimWorld.Biotech">1</ToxicEnvironmentResistance>
+			<ToxicEnvironmentResistance>1</ToxicEnvironmentResistance>
 			<Wildness>0.4</Wildness>
 		</statBases>
 		<tools>

--- a/1.6/Defs/ThingDefs_Races/Races_MammothWorm.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_MammothWorm.xml
@@ -121,12 +121,14 @@
 			</li>
 		</modExtensions>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_MammothWorm</defName>
 		<race>AA_MammothWorm</race>
 		<label>mammoth worm</label>
 		<combatPower>200</combatPower>
+		<canArriveManhunter>true</canArriveManhunter>
 		<ecoSystemWeight>0.2</ecoSystemWeight>
+		<defaultFactionDef IsNull="True" />
 		<wildGroupSize>
 			<min>3</min>
 			<max>5</max>

--- a/1.6/Defs/ThingDefs_Races/Races_MegaLouse.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_MegaLouse.xml
@@ -126,13 +126,15 @@
 			</li>
 		</modExtensions>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_MegaLouse</defName>
 		<label>megalouse</label>
 		<labelPlural>megalice</labelPlural>
 		<race>AA_MegaLouse</race>
 		<combatPower>150</combatPower>
+		<canArriveManhunter>true</canArriveManhunter>
 		<ecoSystemWeight>0.2</ecoSystemWeight>
+		<defaultFactionDef IsNull="True" />
 		<wildGroupSize>
 			<min>5</min>
 			<max>15</max>

--- a/1.6/Defs/ThingDefs_Races/Races_Murkling.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Murkling.xml
@@ -9,7 +9,7 @@
 			<MarketValue>35</MarketValue>
 			<ComfyTemperatureMin>-35</ComfyTemperatureMin>
 			<FilthRate>2</FilthRate>
-			<ToxicEnvironmentResistance MayRequire="Ludeon.RimWorld.Biotech">1</ToxicEnvironmentResistance>
+			<ToxicEnvironmentResistance>1</ToxicEnvironmentResistance>
 			<Wildness>0.6</Wildness>
 		</statBases>
 		<tools>

--- a/1.6/Defs/ThingDefs_Races/Races_Ravager.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Ravager.xml
@@ -106,13 +106,13 @@
 			</li>
 		</modExtensions>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_Ravager</defName>
 		<label>ravager</label>
 		<race>AA_Ravager</race>
 		<combatPower>220</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
-		<defaultFactionType>Insect</defaultFactionType>
+		<defaultFactionDef>Insect</defaultFactionDef>
 		<ecoSystemWeight>0.25</ecoSystemWeight>
 		<lifeStages>
 			<li>

--- a/1.6/Defs/ThingDefs_Races/Races_Thermadon.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Thermadon.xml
@@ -107,12 +107,13 @@
 			</li>
 		</modExtensions>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_Thermadon</defName>
 		<label>thermadon</label>
 		<race>AA_Thermadon</race>
 		<combatPower>175</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
+		<defaultFactionType>Insect</defaultFactionType>
 		<lifeStages>
 			<li>
 				<bodyGraphicData>

--- a/1.6/Mods/VFEInsectoids2/Defs/ThingDefs_Races/Races_BlackEmpress.xml
+++ b/1.6/Mods/VFEInsectoids2/Defs/ThingDefs_Races/Races_BlackEmpress.xml
@@ -4,7 +4,7 @@
 	<ThingDef ParentName="VFEI2_BaseInsect">
 		<defName>VFEI2_BlackEmpress</defName>
 		<label>black empress</label>
-		<description>An incredibly rare and monstrously large insectoid of the Black Hive geneline. Unlike its Sorne counterpart, the black empress is not worried about creating offspring, feeling more concerned about acting as an absolute nightmare in close quarters combat. She can tore through heavy armor as if it wasn't there, but what makes her particularly dangerous is her ability to absolutely melt any mechanoids it encounters with a ranged spit attack. Upon death, it’s possible to extract a Black Hive pherocore from her body.</description>
+		<description>An incredibly rare and monstrously large insectoid of the Black Hive geneline. Unlike its Sorne counterpart, the black empress is not worried about creating offspring, feeling more concerned about acting as an absolute nightmare in close quarters combat. She can tear through heavy armor as if it wasn't there, but what makes her particularly dangerous is her ability to absolutely melt any mechanoids it encounters with a ranged spit attack. Upon death, it’s possible to extract a Black Hive pherocore from her body.</description>
 		<statBases>
 			<MoveSpeed>5.6</MoveSpeed>
 			<Flammability>0.2</Flammability>
@@ -109,14 +109,14 @@
       
     </killedLeavings>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>VFEI2_BlackEmpress</defName>
 		<label>black empress</label>
 		<race>VFEI2_BlackEmpress</race>
 		<combatPower>800</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
 		<ecoSystemWeight>0.50</ecoSystemWeight>
-		<defaultFactionType>Insect</defaultFactionType>
+		<defaultFactionDef>Insect</defaultFactionDef>
 		<aiAvoidCover>false</aiAvoidCover>
 		<defendPointRadius>0</defendPointRadius>
 		<lifeStages>

--- a/1.6/Mods/VFEInsectoids2/Defs/ThingDefs_Races/Races_BlackQueen.xml
+++ b/1.6/Mods/VFEInsectoids2/Defs/ThingDefs_Races/Races_BlackQueen.xml
@@ -93,14 +93,14 @@
 			<soundMeleeMiss>Pawn_Melee_BigBash_Miss</soundMeleeMiss>
 		</race>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>VFEI2_BlackQueen</defName>
 		<label>black insectoid queen</label>
 		<race>VFEI2_BlackQueen</race>
 		<combatPower>450</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
 		<ecoSystemWeight>0.50</ecoSystemWeight>
-		<defaultFactionType>Insect</defaultFactionType>
+		<defaultFactionDef>Insect</defaultFactionDef>
 		<aiAvoidCover>false</aiAvoidCover>
 		<defendPointRadius>0</defendPointRadius>
 		<lifeStages>

--- a/1.6/Mods/VFEInsectoids2/Defs/ThingDefs_Races/Races_BlackSwarmling.xml
+++ b/1.6/Mods/VFEInsectoids2/Defs/ThingDefs_Races/Races_BlackSwarmling.xml
@@ -80,14 +80,14 @@
 			</li>
 		</comps>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 			<defName>VFEI2_BlackSwarmling</defName>
 		<label>black swarmlings</label>
 		<race>VFEI2_BlackSwarmling</race>
 		<combatPower>10</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
 		<ecoSystemWeight>0.50</ecoSystemWeight>
-		<defaultFactionType>Insect</defaultFactionType>
+		<defaultFactionDef>Insect</defaultFactionDef>
 		<aiAvoidCover>false</aiAvoidCover>
 		<defendPointRadius>0</defendPointRadius>
 		<lifeStages>

--- a/1.6/Mods/VanillaPsycastsExpanded/Defs/ThingDefs_Races/Races_BlackHive_Psycasts.xml
+++ b/1.6/Mods/VanillaPsycastsExpanded/Defs/ThingDefs_Races/Races_BlackHive_Psycasts.xml
@@ -98,12 +98,13 @@
 		</modExtensions>
 	</ThingDef>
 	
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_BlackScarab_Temporary</defName>
 		<label>summoned black scarab</label>
 		<race>AA_BlackScarab_Temporary</race>
 		<combatPower>50</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
+		<defaultFactionDef IsNull="True" />
 		<alternateGraphicChance>1</alternateGraphicChance>
 		<alternateGraphics>
 			<li>
@@ -251,12 +252,13 @@
 		</modExtensions>
 	</ThingDef>
 
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_BlackSpelopede_Temporary</defName>
 		<label>summoned black spelopede</label>
 		<race>AA_BlackSpelopede_Temporary</race>
 		<combatPower>85</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
+		<defaultFactionDef IsNull="True" />
 		
 		<alternateGraphicChance>1</alternateGraphicChance>
 		<alternateGraphics>
@@ -409,12 +411,13 @@
 		</modExtensions>
 	</ThingDef>
 
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_BlackSpider_Temporary</defName>
 		<label>summoned blackspider</label>
 		<race>AA_BlackSpider_Temporary</race>
 		<combatPower>175</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
+		<defaultFactionDef IsNull="True" />
 		
 		<alternateGraphicChance>1</alternateGraphicChance>
 		<alternateGraphics>
@@ -581,13 +584,14 @@
 		</modExtensions>
 	</ThingDef>
 
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_MammothWorm_Temporary</defName>
 		<race>AA_MammothWorm_Temporary</race>
 		<label>summoned mammoth worm</label>
 		<combatPower>200</combatPower>
 		<ecoSystemWeight>0.2</ecoSystemWeight>
 <canArriveManhunter>false</canArriveManhunter>
+		<defaultFactionDef IsNull="True" />
 		<lifeStages>
 			
 			<li>

--- a/1.6/Mods/VanillaPsycastsExpanded/Defs/ThingDefs_Races/Races_BlackLarva.xml
+++ b/1.6/Mods/VanillaPsycastsExpanded/Defs/ThingDefs_Races/Races_BlackLarva.xml
@@ -48,13 +48,14 @@
 			<soundMeleeMiss>Pawn_Melee_BigBash_Miss</soundMeleeMiss>
 		</race>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AA_BlackLarvae</defName>
 		<label>black larvae</label>
 		<race>AA_BlackLarvae</race>
 		<combatPower>10</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
 		<ecoSystemWeight>0.50</ecoSystemWeight>
+		<defaultFactionDef IsNull="True" />
 		<lifeStages>
 			<li>
 				<bodyGraphicData>

--- a/1.6/Mods/VanillaPsycastsExpanded/Defs/ThingDefs_Races/Races_BlackQueen_Psycasts.xml
+++ b/1.6/Mods/VanillaPsycastsExpanded/Defs/ThingDefs_Races/Races_BlackQueen_Psycasts.xml
@@ -87,13 +87,14 @@
 			<soundMeleeMiss>Pawn_Melee_BigBash_Miss</soundMeleeMiss>
 		</race>
 	</ThingDef>
-	<PawnKindDef ParentName="AnimalKindBase">
+	<PawnKindDef ParentName="InsectKindBase">
 		<defName>AAVPE_BlackQueen</defName>
 		<label>summoned black queen</label>
 		<race>AAVPE_BlackQueen</race>
 		<combatPower>300</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
 		<ecoSystemWeight>0.50</ecoSystemWeight>
+		<defaultFactionDef IsNull="True" />
 		<lifeStages>
 			<li>
 				<bodyGraphicData>


### PR DESCRIPTION
First, any place using `<ToxicEnvironmentResistance>` had its Biotech requirement removed, since it's a vanilla feature now.

Second, I changed `<defaultFactionType>` to `<defaultFactionDef>`. It was renamed in-game, so I thought it may be for the best to do it. The old name was kept as an alias in-game, which is why it still works.

Third, any black hive insectoids were changed so their `<PawnKindDef>` inherits from `InsectKindBase`, rather than `AnimalKindBase`. This means all the black hive insectoids will benefit from extra movement speed on insectoid terrain. Using the vanilla's insect base ensures that any other movement speed modifications, like the ones from VFE-I2, are also applied without needing any extra changes besides that.

From animals using `BaseInsect2` or `AA_AlphaBaseInsect` as a base, I did NOT include changes to:
- Any of the 'lisks
- Barb slinger
- Chemfuel myrmidon
- Any other insects that inherit from different defs

I wasn't sure if you wanted them to benefit from insectoid terrain or not, so I just left them as-is.

Additional notes due to using `InsectKindBase`:
- It forces `<canArriveManhunter>` to false, so if any animal had it to true/unspecified, I forced it back to true
- It forces `<defaultFactionDef>` to `Insect`, so again - I forced it to null if it was unspecified before

If you don't want that, you may want to go and change it.